### PR TITLE
File picker field prevent from displaying file outside the current page #22

### DIFF
--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -182,13 +182,16 @@
     #else
       #set ($document = $doc)
     #end
-    #set ($attachment = $document.getAttachment($file))
+    ## The file macro parameter can hold either only the attachment name for xwiki versions below 11.5, or the full
+    ## attachment reference on newer versions, since this is needed for the attachment picker.
+    #set ($filename = $services.model.resolveAttachment($file).getName())
+    #set ($attachment = $document.getAttachment($filename))
     #set ($url = $NULL)
     #if ($attachment)
-      #set ($url = $document.getAttachmentURL($file))
+      #set ($url = $document.getAttachmentURL($filename))
     #elseif ($asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
       #set ($document = $xwiki.getDocumentAsAuthor($docname))
-      #set ($attachment = $document.getAttachment($file))
+      #set ($attachment = $document.getAttachment($filename))
       #if( $attachment)
         #set ($digestFactory = $services.component.getInstance('org.xwiki.crypto.DigestFactory', 'SHA-1'))
         #set ($encoder = $services.component.getInstance('org.xwiki.crypto.BinaryStringEncoder', 'URLBase64'))


### PR DESCRIPTION
* consider only the filename of the reference added inside the file macro parameter; this is needed since the full reference is used in xwiki versions starting with 11.5 instead of only the filename