### PR TITLE
Differences between the document from the attachment picker and the document macro paremeter #24

### DIFF
--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -175,7 +175,7 @@
 #macro (getUrlFromFile $file)
   #set ($url = $NULL)
   ## If the url is not directly specified, the attachment reference can be taken either directly from the file macro
-  ## parameter for xwiki versions starting with 11.5, since an attachment picker is used, or by using the file and
+  ## parameter for xwiki versions starting with 11.5, since an attachment picker is used, or by using both the file and
   ## document parameters.
   #if ($file.startsWith('http://') || $file.startsWith('https://'))
     #set ($url = $file)

--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -177,22 +177,31 @@
   #if ($file.startsWith('http://') || $file.startsWith('https://'))
     #set ($url = $file)
   #else
+    ## Checking what document and attachment to use.
+    #set ($authorRightsNeeded = false)
     #if ("$!docname" != '')
       #set ($document = $xwiki.getDocument($docname))
+      #if (!$document.getAttachment($file) &amp;&amp; $asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
+        #set ($document = $xwiki.getDocumentAsAuthor($docname))
+        #set ($authorRightsNeeded = true)
+      #end
     #else
       #set ($document = $doc)
     #end
-    ## The file macro parameter can hold either only the attachment name for xwiki versions below 11.5, or the full
-    ## attachment reference on newer versions, since this is needed for the attachment picker.
-    #set ($filename = $services.model.resolveAttachment($file).getName())
-    #set ($attachment = $document.getAttachment($filename))
+    #set ($attachment = $document.getAttachment($file))
+    #if (!$attachment)
+      #set ($attachmentRef = $services.model.resolveAttachment($file))
+      #set ($document = $xwiki.getDocument($attachmentRef.getParent()))
+      #set ($attachment = $document.getAttachment($attachmentRef.getName()))
+    #end
+    ## Getting the url.
+    #set ($filename = $file)
     #set ($url = $NULL)
     #if ($attachment)
-      #set ($url = $document.getAttachmentURL($filename))
-    #elseif ($asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
-      #set ($document = $xwiki.getDocumentAsAuthor($docname))
-      #set ($attachment = $document.getAttachment($filename))
-      #if( $attachment)
+      #set ($filename = $attachment.getFilename())
+      #if (!$authorRightsNeeded)
+        #set ($url = $document.getAttachmentURL($attachment.getFilename()))
+      #else
         #set ($digestFactory = $services.component.getInstance('org.xwiki.crypto.DigestFactory', 'SHA-1'))
         #set ($encoder = $services.component.getInstance('org.xwiki.crypto.BinaryStringEncoder', 'URLBase64'))
         #if ($digestFactory &amp;&amp; $encoder)
@@ -245,7 +254,7 @@
   #elseif (!$document || $document.isNew())
     {{error}}$services.localization.render('pdfviewer.error.nodocument', [$escapetool.html($escapetool.html($docname))]){{/error}}
   #else
-    {{error}}$services.localization.render('pdfviewer.error.noattachment', [$escapetool.html($file), $escapetool.html($services.model.serialize($document.documentReference, 'default'))]){{/error}}
+    {{error}}$services.localization.render('pdfviewer.error.noattachment', [$escapetool.html($filename), $escapetool.html($services.model.serialize($document.documentReference, 'default'))]){{/error}}
   #end
 #end
 

--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -188,7 +188,7 @@
     #if ("$!docname" != '')
       #set ($document = $xwiki.getDocument($docname))
       #if (!$document.getAttachment($file) &amp;&amp; $asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp;
-        $xwiki.exists('XWiki.PDFViewerService'))
+          $xwiki.exists('XWiki.PDFViewerService'))
         #set ($document = $xwiki.getDocumentAsAuthor($docname))
         #set ($authorRightsNeeded = true)
       #end
@@ -198,8 +198,8 @@
     #set ($attachment = $document.getAttachment($file))
     #if (!$attachment)
       #set ($attachmentReference = $services.model.resolveAttachment($file))
-      #set ($filename = $attachmentReference.getName())
-      #set ($document = $xwiki.getDocument($attachmentReference.getParent()))
+      #set ($filename = $attachmentReference.name)
+      #set ($document = $xwiki.getDocument($attachmentReference.parent))
       #set ($attachment = $document.getAttachment($filename))
     #end
     #set ($url = $NULL)

--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -174,14 +174,21 @@
 {{velocity output="false"}}
 #macro (getUrlFromFile $file)
   #set ($url = $NULL)
+  ## If the url is not directly specified, the attachment reference can be taken either directly from the file macro
+  ## parameter for xwiki versions starting with 11.5, since an attachment picker is used, or by using the file and
+  ## document parameters.
   #if ($file.startsWith('http://') || $file.startsWith('https://'))
     #set ($url = $file)
   #else
-    ## Checking what document and attachment to use.
+    ## For backwards compatibility with the macros added in older versions, first it is checked if the file name
+    ## specified exists on the defined document or on the current one before considering the file parameter as the full
+    ## reference. The filename is needed for the error message when no attachment is found.
+    #set ($filename = $file)
     #set ($authorRightsNeeded = false)
     #if ("$!docname" != '')
       #set ($document = $xwiki.getDocument($docname))
-      #if (!$document.getAttachment($file) &amp;&amp; $asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
+      #if (!$document.getAttachment($file) &amp;&amp; $asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp;
+        $xwiki.exists('XWiki.PDFViewerService'))
         #set ($document = $xwiki.getDocumentAsAuthor($docname))
         #set ($authorRightsNeeded = true)
       #end
@@ -190,15 +197,13 @@
     #end
     #set ($attachment = $document.getAttachment($file))
     #if (!$attachment)
-      #set ($attachmentRef = $services.model.resolveAttachment($file))
-      #set ($document = $xwiki.getDocument($attachmentRef.getParent()))
-      #set ($attachment = $document.getAttachment($attachmentRef.getName()))
+      #set ($attachmentReference = $services.model.resolveAttachment($file))
+      #set ($filename = $attachmentReference.getName())
+      #set ($document = $xwiki.getDocument($attachmentReference.getParent()))
+      #set ($attachment = $document.getAttachment($filename))
     #end
-    ## Getting the url.
-    #set ($filename = $file)
     #set ($url = $NULL)
     #if ($attachment)
-      #set ($filename = $attachment.getFilename())
       #if (!$authorRightsNeeded)
         #set ($url = $document.getAttachmentURL($attachment.getFilename()))
       #else

--- a/wiki/src/main/resources/XWiki/PDFViewerMacroTranslations.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacroTranslations.xml
@@ -42,9 +42,9 @@
   <content>rendering.macro.pdfviewer.name=PDF Viewer
 rendering.macro.pdfviewer.description=PDF Viewer based on Mozilla pdf.js
 rendering.macro.pdfviewer.parameter.file.name=File
-rendering.macro.pdfviewer.parameter.file.description=Name of the PDF file or absolute URL to the PDF file
+rendering.macro.pdfviewer.parameter.file.description=The full PDF file reference, an absolute URL or only the name of the attachment when is used along with the document parameter.
 rendering.macro.pdfviewer.parameter.document.name=Document
-rendering.macro.pdfviewer.parameter.document.description=Reference to the XWiki document to which the file is attached. If not defined, the current document is used. If file argument is an absolute URL, this argument is ignored.
+rendering.macro.pdfviewer.parameter.document.description=Reference to the XWiki document to which the file is attached. If not defined, the current document or only the file parameter are used. If file argument is an absolute URL or the attachment does not exists, this argument is ignored.
 rendering.macro.pdfviewer.parameter.width.name=Width
 rendering.macro.pdfviewer.parameter.width.description=The viewer width, in pixels. If not defined the default value will be used
 rendering.macro.pdfviewer.parameter.height.name=Height


### PR DESCRIPTION
* consider that the file parameter will hold a resource reference in recent versions, while still being backwards compatible
* update the parameters description for the new logic

**Note** that after #26 is fixed, the document parameter could be deleted and a migration added