### PR TITLE
Differences between the document from the attachment picker and the document macro paremeter #24

### DIFF
--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -172,11 +172,13 @@
       <code>{{include reference="Licenses.Code.VelocityMacros"/}}
 
 {{velocity output="false"}}
-#macro (checkDocumentAsAuthor $documentName)
-  #if (!$services.security.authorization.hasAccess('view', $documentName) &amp;&amp; $asAuthor &amp;&amp;
+#macro (maybeGetDocumentAsAuthor $documentReference $asAuthor)
+  #if (!$services.security.authorization.hasAccess('view', $documentReference) &amp;&amp; $asAuthor &amp;&amp;
       $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
-    #set ($document = $xwiki.getDocumentAsAuthor($documentName))
+    #set ($document = $xwiki.getDocumentAsAuthor($documentReference))
     #set ($authorRightsNeeded = true)
+  #else
+    #set ($document = $xwiki.getDocument($documentReference))
   #end
 #end
 
@@ -194,8 +196,7 @@
     #set ($filename = $file)
     #set ($authorRightsNeeded = false)
     #if ("$!docname" != '')
-      #set ($document = $xwiki.getDocument($docname))
-      #checkDocumentAsAuthor($docname)
+      #maybeGetDocumentAsAuthor($docname $asAuthor)
     #else
       #set ($document = $doc)
     #end
@@ -203,8 +204,7 @@
     #if (!$attachment)
       #set ($attachmentReference = $services.model.resolveAttachment($file))
       #set ($filename = $attachmentReference.name)
-      #set ($document = $xwiki.getDocument($attachmentReference.parent))
-      #checkDocumentAsAuthor($attachmentReference.parent)
+      #maybeGetDocumentAsAuthor($attachmentReference.parent $asAuthor)
       #set ($attachment = $document.getAttachment($filename))
     #end
     #set ($url = $NULL)

--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -172,6 +172,13 @@
       <code>{{include reference="Licenses.Code.VelocityMacros"/}}
 
 {{velocity output="false"}}
+#macro (getDocumentAsAuthor $documentName)
+  #if ($asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
+    #set ($document = $xwiki.getDocumentAsAuthor($documentName))
+    #set ($authorRightsNeeded = true)
+  #end
+#end
+
 #macro (getUrlFromFile $file)
   #set ($url = $NULL)
   ## If the url is not directly specified, the attachment reference can be taken either directly from the file macro
@@ -187,10 +194,8 @@
     #set ($authorRightsNeeded = false)
     #if ("$!docname" != '')
       #set ($document = $xwiki.getDocument($docname))
-      #if (!$document.getAttachment($file) &amp;&amp; $asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp;
-          $xwiki.exists('XWiki.PDFViewerService'))
-        #set ($document = $xwiki.getDocumentAsAuthor($docname))
-        #set ($authorRightsNeeded = true)
+      #if (!$document.getAttachment($file))
+        #getDocumentAsAuthor($docname)
       #end
     #else
       #set ($document = $doc)
@@ -200,6 +205,9 @@
       #set ($attachmentReference = $services.model.resolveAttachment($file))
       #set ($filename = $attachmentReference.name)
       #set ($document = $xwiki.getDocument($attachmentReference.parent))
+      #if (!$document.getAttachment($filename))
+        #getDocumentAsAuthor($attachmentReference.parent)
+      #end
       #set ($attachment = $document.getAttachment($filename))
     #end
     #set ($url = $NULL)

--- a/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
+++ b/wiki/src/main/resources/XWiki/PDFViewerMacro.xml
@@ -172,8 +172,9 @@
       <code>{{include reference="Licenses.Code.VelocityMacros"/}}
 
 {{velocity output="false"}}
-#macro (getDocumentAsAuthor $documentName)
-  #if ($asAuthor &amp;&amp; $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
+#macro (checkDocumentAsAuthor $documentName)
+  #if (!$services.security.authorization.hasAccess('view', $documentName) &amp;&amp; $asAuthor &amp;&amp;
+      $xwiki.hasProgrammingRights() &amp;&amp; $xwiki.exists('XWiki.PDFViewerService'))
     #set ($document = $xwiki.getDocumentAsAuthor($documentName))
     #set ($authorRightsNeeded = true)
   #end
@@ -194,9 +195,7 @@
     #set ($authorRightsNeeded = false)
     #if ("$!docname" != '')
       #set ($document = $xwiki.getDocument($docname))
-      #if (!$document.getAttachment($file))
-        #getDocumentAsAuthor($docname)
-      #end
+      #checkDocumentAsAuthor($docname)
     #else
       #set ($document = $doc)
     #end
@@ -205,9 +204,7 @@
       #set ($attachmentReference = $services.model.resolveAttachment($file))
       #set ($filename = $attachmentReference.name)
       #set ($document = $xwiki.getDocument($attachmentReference.parent))
-      #if (!$document.getAttachment($filename))
-        #getDocumentAsAuthor($attachmentReference.parent)
-      #end
+      #checkDocumentAsAuthor($attachmentReference.parent)
       #set ($attachment = $document.getAttachment($filename))
     #end
     #set ($url = $NULL)


### PR DESCRIPTION
* consider the rights of the last author of the document also for the attachments specified with full reference (from attachment picker), not just when the document parameter is specified