### PR TITLE
PDF files with spaces in their names are not properly viewed anymore

### DIFF
--- a/api/src/main/java/com/xwiki/pdfviewer/macro/PDFViewerMacroParameters.java
+++ b/api/src/main/java/com/xwiki/pdfviewer/macro/PDFViewerMacroParameters.java
@@ -19,8 +19,6 @@
  */
 package com.xwiki.pdfviewer.macro;
 
-import java.util.List;
-
 import org.xwiki.properties.annotation.PropertyAdvanced;
 import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyDisplayType;
@@ -31,10 +29,11 @@ import com.xwiki.pdfviewer.PDFResourceReference;
 public class PDFViewerMacroParameters
 {
     /**
-     * The PDF files to be viewed. Use the full attachment reference to specify a PDF file, an absolute URL or only the
-     * name of the attachment when is used along with the document parameter.
+     * One or multiple PDF files to be viewed. In case multiple files are defined, the {@code String} will contain a
+     * list with comma as delimiter. Use the full attachment reference to specify a PDF file, an absolute URL or only
+     * the name of the attachment when is used along with the document parameter.
      */
-    private List<String> files;
+    private String file;
 
     /**
      * The viewer width. Uses a percentage value, for example: 25%, 50%, 100%.
@@ -62,26 +61,26 @@ public class PDFViewerMacroParameters
     private String asAuthor = "0";
 
     /**
-     * @return the list of PDF files
+     * @return one or a list of PDF files
      */
-    public List<String> getFiles()
+    public String getFile()
     {
-        return this.files;
+        return this.file;
     }
 
     /**
-     * Set the value of the PDF files. One file is represented by using a full attachment reference, an absolute URL or
-     * simply the file name.
+     * Set the value of one or multiple files. One file is represented by using a full attachment reference, an absolute
+     * URL or simply the file name.
      * 
-     * @param files the list of PDF files
+     * @param file one or a list of PDF files
      */
     @PropertyDisplayType(PDFResourceReference.class)
     @PropertyMandatory
     @PropertyDescription("The full PDF file reference, an absolute URL or only the name of the attachment when is used "
         + "along with the document parameter. Multiple files can be defined.")
-    public void setFile(List<String> files)
+    public void setFile(String file)
     {
-        this.files = files;
+        this.file = file;
     }
 
     /**

--- a/api/src/main/resources/templates/pdfviewer/pdfviewer.vm
+++ b/api/src/main/resources/templates/pdfviewer/pdfviewer.vm
@@ -117,11 +117,12 @@
   #set ($width = $params.width)
   #set ($height = $params.height)
   #set ($filesDocument = $params.document)
-  #set ($files = $params.files)
+  #set ($fileParam = $params.file)
   #set ($asAuthor = $params.asAuthor && ($params.asAuthor == 'true' || $params.asAuthor == 'yes' || $params.asAuthor == '1'))
-  #if (!$files)
+  #if (!$fileParam)
     #error("$services.localization.render('pdfviewer.error.nofile')")
   #else
+    #set ($files = $fileParam.split(','))
     #if ($files.size() == 1)
       #displayFile($files[0] $filesDocument)
     #else


### PR DESCRIPTION
* changed back the file parameter to String type for avoiding the default converter and use the manual split by comma