### PR TITLE
The 'Upload file' button does not appear when trying to upload using the PDF Viewer Macro, if edit right is not given at wiki level to that group/user #44

### DIFF
--- a/api/src/main/resources/templates/html_displayer/pdfresourcereference/edit.vm
+++ b/api/src/main/resources/templates/html_displayer/pdfresourcereference/edit.vm
@@ -20,7 +20,7 @@
 #set ($pdfFileNameExtensions = '.pdf')
 #set ($pdfMediaTypes = 'application/pdf')
 #set ($parameters = {
-    'data-upload-allowed': $services.security.authorization.hasAccess('edit'),
+    'data-upload-allowed': true,
     'data-accept': "$pdfFileNameExtensions, $pdfMediaTypes",
     'placeholder': $services.localization.render('rendering.macro.pdfviewer.placeholder'),
     'multiple': 'multiple'


### PR DESCRIPTION
The `edit.vm` file linked to the attachment macro parameter determines whether the user had the right to upload a file or not by calling: `$services.security.authorization.hasAccess('edit')`. This call checks if the current user has the `edit` right over `CKEditor.MacroService` document, rather than the document that he is currently editing. The default setting for a freshly installed XWiki, is that `XWikiAllGroup` has edit rights globally. In this issue, that right was revoked and thus, the aforementioned check would return `false` because, indeed, the user does not have the edit right over `CKEditor.MacroService` anymore. 

The fix is to replace the line in edit.vm from this:
```
...
'data-upload-allowed': $services.security.authorization.hasAccess('edit'),
...
```
to this:
```
...
'data-upload-allowed': true,
...
```

For the modal of a macro to appear and call the displayer for a specific macro parameter, the user needs to be in edit mode and thus have the edit right over the current document. Given this, another call to check if the user has edit right is not necessary.
