### PR TITLE
Displaying PDF files from an external URL fails #68

### DIFF
--- a/macro-pdfviewer-webjar/pom.xml
+++ b/macro-pdfviewer-webjar/pom.xml
@@ -94,7 +94,7 @@
                   <value>$0;
   const queryString = document.location.search.substring(1);
   const params = (0, _ui_utils_js__WEBPACK_IMPORTED_MODULE_0__.parseQueryString)(queryString);
-  const trustedOrigins = params.get('trustedorigins');
+  const trustedOrigins = (params.get && params.get('trustedorigins')) || params.trustedorigins;
   if (trustedOrigins !== undefined &amp;&amp; trustedOrigins !== '') {
     HOSTED_VIEWER_ORIGINS.push.apply(HOSTED_VIEWER_ORIGINS, trustedOrigins.split(',')) }</value>
                 </replacement>


### PR DESCRIPTION
Refactored trusted origins handling, as the `params` variable is a map object.